### PR TITLE
override `IsAsync` lead to recursion

### DIFF
--- a/uFrameECS/Designer/Editor/Nodes/HandlerNode.cs
+++ b/uFrameECS/Designer/Editor/Nodes/HandlerNode.cs
@@ -41,7 +41,7 @@ namespace uFrame.ECS.Editor
             get { return false; }
         }
 
-        public override bool IsAsync
+        public new bool IsAsync
         {
             get { return FilterNodes.OfType<SequenceItemNode>().Any(p => p.IsAsync); }
         }


### PR DESCRIPTION
override `IsAsync` lead to recursion.
Unity editor raise a stackoverflow exception and crashed.
