### PR TITLE
Code gen error while remove `a.Cast<object>().ToArray();` 

### DIFF
--- a/uFrameCore/Editor/Systems/Compiling/CodeGen/CodeTemplates/impl/TemplateContext.cs
+++ b/uFrameCore/Editor/Systems/Compiling/CodeGen/CodeTemplates/impl/TemplateContext.cs
@@ -419,17 +419,16 @@ namespace uFrame.Editor.Compiling.CodeGen
 
             CurrentDeclaration.Members.Add(dom);
 
-            //var result = 
-            info.Invoke(instance, args.ToArray());
-            //var a = result as IEnumerable;
-            //if (a != null)
-            //{
-            //    var dummyIteraters = a.Cast<object>().ToArray();
+            var result = info.Invoke(instance, args.ToArray());
+            var a = result as IEnumerable;
+            if (a != null)
+            {
+                a.Cast<object>().ToArray();
             //    foreach (var item in dummyIteraters)
             //    {
 
             //    }
-            //}
+            }
 
             PopStatements();
 


### PR DESCRIPTION
statement `a.Cast<object>().ToArray()`  will trigger method [GroupTemplate.Install](https://github.com/uFrame/ALLINONE/blob/dev/uFrameECS/Designer/Editor/Templates/GroupTemplate.cs#L15).

Remove it can lead to code gen error.
